### PR TITLE
TC-63: Locations CSV Exporting

### DIFF
--- a/src/main/java/edu/wpi/cs3733/D22/teamC/App.java
+++ b/src/main/java/edu/wpi/cs3733/D22/teamC/App.java
@@ -1,5 +1,9 @@
 package edu.wpi.cs3733.D22.teamC;
 
+import edu.wpi.cs3733.D22.teamC.entity.location.Location;
+import edu.wpi.cs3733.D22.teamC.entity.location.LocationDAO;
+import edu.wpi.cs3733.D22.teamC.entity.location.LocationDAOImpl;
+import edu.wpi.cs3733.D22.teamC.fileio.csv.LocationCSVWriter;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
@@ -8,6 +12,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
+import java.util.List;
 
 @Slf4j
 public class App extends Application {
@@ -47,6 +52,14 @@ public class App extends Application {
 
     @Override
     public void stop() {
+        // Export CSV Data
+        LocationCSVWriter csvWriter = new LocationCSVWriter();
+        LocationDAO locationDAO = new LocationDAOImpl();
+        List<Location> locations = locationDAO.getAllLocations();
+        if (locations != null) {
+            csvWriter.writeFile("TowerLocations.csv", locations);
+        }
+
         // Shutdown Database Manager
         DBManager.shutdown();
 

--- a/src/main/java/edu/wpi/cs3733/D22/teamC/fileio/csv/CSVWriter.java
+++ b/src/main/java/edu/wpi/cs3733/D22/teamC/fileio/csv/CSVWriter.java
@@ -1,0 +1,65 @@
+package edu.wpi.cs3733.D22.teamC.fileio.csv;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An abstract class for CSVWriters
+ * @param <T> The type of object the implementing CSVWriter will write to.
+ */
+public abstract class CSVWriter<T> {
+    /**
+     * Compile and write Objects of type T to a CSV file
+     * @param fileName The designated CSV output file.
+     * @param objects The list of Objects of T to write to CSV
+     * @return true if successful, else false
+     */
+    public boolean writeFile(String fileName, List<T> objects) {
+        // Convert Objects to List<String[]>
+        List<String[]> objectAttributesList = objects.stream().map(object -> compileObject(object)).collect(Collectors.toList());
+
+        // Convert List<String[]> to Data Stream
+        Stream dataStream = objectAttributesList.stream().map(this::convertToCSV);
+
+        // Write Headers to CSV
+        String headerString = convertToCSV(compileHeaders());
+
+        // Write Data Stream to CSV Output File
+        File outputFile = new File(fileName);
+        try (PrintWriter pw = new PrintWriter(outputFile)) {
+            pw.println(headerString);
+            dataStream.forEach(pw::println);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        return outputFile.exists();
+    }
+
+    /**
+     * Compile the attributes of an Object, creating a String[] to be inserted into the CSV
+     * @param object The Object whose attributes are to be compiled
+     * @return Ordered String[] of compiled attributes
+     */
+    protected abstract String[] compileObject(T object);
+
+    /**
+     * Compile the headers of this Object type T, creating a String[] for the header of the CSV
+     * @return Ordered String[] of headers
+     */
+    protected abstract String[] compileHeaders();
+
+    /**
+     * Convert data in String[] into a CSV line.
+     * @param data String[] of items to be linked as a CSV line.
+     * @return A single String to be inserted as a line into a CSV file.
+     */
+    private String convertToCSV(String[] data) {
+        return Stream.of(data).collect(Collectors.joining(","));
+    }
+}

--- a/src/main/java/edu/wpi/cs3733/D22/teamC/fileio/csv/CSVWriter.java
+++ b/src/main/java/edu/wpi/cs3733/D22/teamC/fileio/csv/CSVWriter.java
@@ -8,31 +8,31 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * An abstract class for CSVWriters
+ * An abstract class for CSVWriters.
  * @param <T> The type of object the implementing CSVWriter will write to.
  */
 public abstract class CSVWriter<T> {
     /**
-     * Compile and write Objects of type T to a CSV file
+     * Compile and write Objects of type T to a CSV file.
      * @param fileName The designated CSV output file.
-     * @param objects The list of Objects of T to write to CSV
-     * @return true if successful, else false
+     * @param objects The list of Objects of T to write to CSV.
+     * @return true if successful, else false.
      */
     public boolean writeFile(String fileName, List<T> objects) {
-        // Convert Objects to List<String[]>
-        List<String[]> objectAttributesList = objects.stream().map(object -> compileObject(object)).collect(Collectors.toList());
+        // Compile headers for output order
+        final String[] headers = compileHeaders();
+        final String headerString = convertToCSV(headers);
 
-        // Convert List<String[]> to Data Stream
-        Stream dataStream = objectAttributesList.stream().map(this::convertToCSV);
+        // Compile objects to Strings according to header order
+        final String[] objectStrings = objects.stream().map(object -> compileObject(object, headers)).toArray(String[]::new);
 
-        // Write Headers to CSV
-        String headerString = convertToCSV(compileHeaders());
-
-        // Write Data Stream to CSV Output File
+        // Write Strings to CSV Output File
         File outputFile = new File(fileName);
         try (PrintWriter pw = new PrintWriter(outputFile)) {
             pw.println(headerString);
-            dataStream.forEach(pw::println);
+            for (String objectString : objectStrings) {
+                pw.println(objectString);
+            }
         } catch (FileNotFoundException e) {
             e.printStackTrace();
             return false;
@@ -42,17 +42,34 @@ public abstract class CSVWriter<T> {
     }
 
     /**
-     * Compile the attributes of an Object, creating a String[] to be inserted into the CSV
-     * @param object The Object whose attributes are to be compiled
-     * @return Ordered String[] of compiled attributes
-     */
-    protected abstract String[] compileObject(T object);
-
-    /**
-     * Compile the headers of this Object type T, creating a String[] for the header of the CSV
-     * @return Ordered String[] of headers
+     * Set an array of headers, representing the order in which they will be output to CSV.
+     * For implementing classes, this must be defined manually.
+     * @return The array of headers to be output to CSV.
      */
     protected abstract String[] compileHeaders();
+
+    /**
+     * Compile the attributes of an Object, creating a String[] to be inserted into the CSV.
+     * @param object The Object whose attributes are to be compiled.
+     * @param headers The Headers which define the order to be output to.
+     * @return Ordered String of compiled attributes.
+     */
+    private String compileObject(T object, String[] headers) {
+        String[] attributes = new String[headers.length];
+        for (int i = 0; i < headers.length; i++) {
+            attributes[i] = compileAttribute(object, headers[i]);
+        }
+        return convertToCSV(attributes);
+    }
+
+    /**
+     * Compile attributes for the current header to return the corresponding String for the given object.
+     * For implementing classes, this function should be a switch case handling each expected header.
+     * @param object The object to be read from.
+     * @param header The header to be mapped to an attribute.
+     * @return String corresponding to the attribute value of the given object and header.
+     */
+    protected abstract String compileAttribute(T object, String header);
 
     /**
      * Convert data in String[] into a CSV line.

--- a/src/main/java/edu/wpi/cs3733/D22/teamC/fileio/csv/LocationCSVWriter.java
+++ b/src/main/java/edu/wpi/cs3733/D22/teamC/fileio/csv/LocationCSVWriter.java
@@ -1,0 +1,63 @@
+package edu.wpi.cs3733.D22.teamC.fileio.csv;
+
+import edu.wpi.cs3733.D22.teamC.entity.location.Location;
+
+public class LocationCSVWriter extends CSVWriter<Location> {
+    /**
+     * Manually define headers of attributes output to CSV.
+     * @return The array of headers to be output to CSV.
+     */
+    @Override
+    protected String[] compileHeaders() {
+        return new String[]{
+                "nodeID",
+                "xcoord",
+                "ycoord",
+                "floor",
+                "building",
+                "nodeType",
+                "longName",
+                "shortName"
+        };
+    }
+
+    /**
+     * Maps headers to a value to get from the object.
+     * @param object The object to be read from.
+     * @param header The header to be mapped to an attribute.
+     * @return The retrieved value to be output to the CSV.
+     */
+    @Override
+    protected String compileAttribute(Location object, String header) {
+        String output = "";
+        switch (header) {
+            case "nodeID":
+                output = object.getNodeID();
+                break;
+            case "xcoord":
+                output = Integer.toString(object.getX());
+                break;
+            case "ycoord":
+                output = Integer.toString(object.getY());
+                break;
+            case "floor":
+                output = object.getFloor();
+                break;
+            case "building":
+                output = object.getBuilding();
+                break;
+            case "nodeType":
+                output = object.getNodeType();
+                break;
+            case "longName":
+                output = object.getLongName();
+                break;
+            case "shortName":
+                output = object.getShortName();
+                break;
+            default:
+                break;
+        }
+        return output;
+    }
+}


### PR DESCRIPTION
Created the abstract CSVWriter class and its LocationCSVWriter implementation for others to use to create their own versions of the CSVReader class.

Also implemented the LocationCSVWriter in accordance with the expected behavior of the prototype, which is to export Location to CSV at the end of the program.

(To test this, you should run TC-62 to import data into the LOCATION Table of the DB. Then, temporarily disable table clearing by switching _emptyTable_ from **true** to **false** in the DBManager default constructor. Lastly, run this TC-63 build and it will export to whatever csv filename you specify in the writeFile function call).